### PR TITLE
improve error message when received body is empty 

### DIFF
--- a/tests/integration.go
+++ b/tests/integration.go
@@ -317,6 +317,11 @@ func assertResponse(actual *http.Response, expected Output) error {
 	}
 
 	if len(expected.Schema) != 0 {
+		if len(bodyBytes) == 0 {
+			return responseError{
+				errMessage: append(errMsgs, "cannot validate empty body"),
+			}
+		}
 		s, err := json.Marshal(expected.Schema)
 		if err != nil {
 			return responseError{
@@ -332,7 +337,7 @@ func assertResponse(actual *http.Response, expected Output) error {
 		result, err := schema.Validate(gojsonschema.NewBytesLoader(bodyBytes))
 		if err != nil {
 			return responseError{
-				errMessage: append(errMsgs, fmt.Sprintf("problem creating the json-schema validator: %s", err)),
+				errMessage: append(errMsgs, fmt.Sprintf("problem validating the body: %s", err)),
 			}
 		}
 		if !result.Valid() {


### PR DESCRIPTION
The error message when a received body is empty is a little bit misleading, and looks like the issue is with the json-schema validator creation (like if it was a bug or error in the integrations test code).

With this PR an specific message is added for the empty body, and the wording for the `Validate` result is changed. 