### PR TITLE
Update Go and Alpine versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,9 @@ DESC := High performance API gateway. Aggregate, filter, manipulate and add midd
 MAINTAINER := Daniel Ortiz <dortiz@krakend.io>
 DOCKER_WDIR := /tmp/fpm
 DOCKER_FPM := devopsfaith/fpm
-GOLANG_VERSION := 1.22.3
+GOLANG_VERSION := 1.22.4
 GLIBC_VERSION := $(shell sh find_glibc.sh)
-ALPINE_VERSION := 3.18
+ALPINE_VERSION := 3.19
 OS_TAG :=
 EXTRA_LDFLAGS :=
 


### PR DESCRIPTION
It appears that Alpine 3.18 is no longer available as a Docker image as of 3 weeks ago:
https://github.com/docker-library/golang/commit/cf7a37dedf1fd5a25ca72075645368d1e3c30c4a for more information on Go Docker container change.