### PR TITLE
Add permissions to upload the security reports

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,11 +42,13 @@ jobs:
           sarif_file: 'trivy-results.sarif'
 
   image-scan:
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
     strategy:
       matrix:
         config:
-          - image: krakend/builder
-            dockerfile: Dockerfile-builder
           - image: krakend/krakend-ce
             dockerfile: Dockerfile
     runs-on: ubuntu-latest


### PR DESCRIPTION
Also removes the builder scan since it's the official golang docker container and it's not used in runtime.