### PR TITLE
perf: improve docker build times

### DIFF
--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -2,7 +2,8 @@ ARG GOLANG_VERSION
 ARG ALPINE_VERSION
 FROM golang:${GOLANG_VERSION}-alpine${ALPINE_VERSION}
 
-RUN apk --no-cache --virtual .build-deps add tar make gcc musl-dev binutils-gold
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    apk add tar make gcc musl-dev binutils-gold
 
 RUN cd / && wget http://musl.cc/aarch64-linux-musl-cross.tgz && \
     tar zxf aarch64-linux-musl-cross.tgz && rm -f aarch64-linux-musl-cross.tgz

--- a/Dockerfile-builder-linux
+++ b/Dockerfile-builder-linux
@@ -1,6 +1,8 @@
 ARG GOLANG_VERSION
 FROM golang:${GOLANG_VERSION}-bullseye
 
-RUN apt-get update && \
-    apt-get install -y gcc make gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu \
-    && rm -rf /var/lib/apt/lists/*
+RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+    --mount=target=/var/cache/apt,type=cache,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && \
+    apt-get install -y gcc make gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu

--- a/Makefile
+++ b/Makefile
@@ -26,23 +26,24 @@ GLIBC_VERSION := $(shell sh find_glibc.sh)
 ALPINE_VERSION := 3.19
 OS_TAG :=
 EXTRA_LDFLAGS :=
+DOCKER_BUILD_ARGS ?=
 
 FPM_OPTS=-s dir -v $(VERSION) -n $(PKGNAME) \
-  --license "$(LICENSE)" \
-  --vendor "$(VENDOR)" \
-  --maintainer "$(MAINTAINER)" \
-  --architecture $(ARCH) \
-  --url "$(URL)" \
-  --description  "$(DESC)" \
+	--license "$(LICENSE)" \
+	--vendor "$(VENDOR)" \
+	--maintainer "$(MAINTAINER)" \
+	--architecture $(ARCH) \
+	--url "$(URL)" \
+	--description  "$(DESC)" \
 	--config-files etc/ \
-  --verbose
+	--verbose
 
 DEB_OPTS= -t deb --deb-user $(USER) \
 	--depends ca-certificates \
 	--depends rsyslog \
 	--depends logrotate \
 	--before-remove builder/scripts/prerm.deb \
-  --after-remove builder/scripts/postrm.deb \
+	--after-remove builder/scripts/postrm.deb \
 	--before-install builder/scripts/preinst.deb
 
 RPM_OPTS =--rpm-user $(USER) \
@@ -56,7 +57,6 @@ all: test
 
 build:
 	@echo "Building the binary..."
-	@go get .
 	@go build -ldflags="-X ${MODULE}/pkg.Version=${VERSION} -X github.com/luraproject/lura/v2/core.KrakendVersion=${VERSION} \
 	-X github.com/luraproject/lura/v2/core.GoVersion=${GOLANG_VERSION} \
 	-X github.com/luraproject/lura/v2/core.GlibcVersion=${GLIBC_VERSION} ${EXTRA_LDFLAGS}" \
@@ -72,13 +72,13 @@ build_on_docker: docker-builder-linux
 
 # Build the container using the Dockerfile (alpine)
 docker:
-	docker build --no-cache --pull --build-arg GOLANG_VERSION=${GOLANG_VERSION} --build-arg ALPINE_VERSION=${ALPINE_VERSION} -t devopsfaith/krakend:${VERSION} .
+	docker build ${DOCKER_BUILD_ARGS} --pull --build-arg GOLANG_VERSION=${GOLANG_VERSION} --build-arg ALPINE_VERSION=${ALPINE_VERSION} -t devopsfaith/krakend:${VERSION} .
 
 docker-builder:
-	docker build --no-cache --pull --build-arg GOLANG_VERSION=${GOLANG_VERSION} --build-arg ALPINE_VERSION=${ALPINE_VERSION} -t krakend/builder:${VERSION} -f Dockerfile-builder .
+	docker build ${DOCKER_BUILD_ARGS} --pull --build-arg GOLANG_VERSION=${GOLANG_VERSION} --build-arg ALPINE_VERSION=${ALPINE_VERSION} -t krakend/builder:${VERSION} -f Dockerfile-builder .
 
 docker-builder-linux:
-	docker build --no-cache --pull --build-arg GOLANG_VERSION=${GOLANG_VERSION} -t krakend/builder:${VERSION}-linux-generic -f Dockerfile-builder-linux .
+	docker build ${DOCKER_BUILD_ARGS} --pull --build-arg GOLANG_VERSION=${GOLANG_VERSION} -t krakend/builder:${VERSION}-linux-generic -f Dockerfile-builder-linux .
 
 benchmark:
 	@mkdir -p bench_res


### PR DESCRIPTION
Improve docker build times by using buildkit cache mounts, an additional layer for `go mod download` and leveraging linked copy.

This reduces the time of all docker build significantly improving developer velocity.

make build - cached
Before: [+] Building 184.7s (16/16) FINISHED
After: [+] Building 0.8s (17/17) FINISHED

make build-builder - cached
Before: [+] Building 38.7s (7/7) FINISHED
After: [+] Building 0.7s (7/7) FINISHED

make docker-builder-Linux - cached
Before: [+] Building 49.9s (6/6) FINISHED
After: [+] Building 0.7s (6/6) FINISHED

Caching can still be disabled by setting the environment variable:
`DOCKER_BUILD_ARGS=--no-cache`

Also correct inconsistent indentation in `Makefile`.