### PR TITLE
remove setting go version variable at link time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,6 @@ build:
 	@echo "Building the binary..."
 	@go get .
 	@go build -ldflags="-X ${MODULE}/pkg.Version=${VERSION} -X github.com/luraproject/lura/v2/core.KrakendVersion=${VERSION} \
-	-X github.com/luraproject/lura/v2/core.GoVersion=${GOLANG_VERSION} \
 	-X github.com/luraproject/lura/v2/core.GlibcVersion=${GLIBC_VERSION} ${EXTRA_LDFLAGS}" \
 	-o ${BIN_NAME} ./cmd/krakend-ce
 	@echo "You can now use ./${BIN_NAME}"


### PR DESCRIPTION
remove setting go version variable at link time

:warning: needs to update dependency to latest lura version that uses runtime to get the go version