### PR TITLE
upgrade old ubuntu versions and use the same in all workflow steps

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v3
 

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -9,7 +9,7 @@ name: Handle Release
 jobs:
   generate:
     name: Create release-artifacts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout the repository
         uses: actions/checkout@master
@@ -71,7 +71,7 @@ jobs:
           key: ${{github.ref}}-artifacts
   upload:
      name: Upload release-artifacts
-     runs-on: ubuntu-20.04
+     runs-on: ubuntu-24.04
      needs: generate
      permissions:
       actions: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ name: Handle Release
 jobs:
   builder:
     name: Generate builder containers
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout the repository
         uses: actions/checkout@master
@@ -65,7 +65,7 @@ jobs:
           labels: ${{ steps.meta-linux-generic.outputs.labels }}
   generate:
     name: Create release-artifacts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     needs: builder
     steps:
       - name: Checkout the repository
@@ -128,7 +128,7 @@ jobs:
           key: ${{github.ref}}-artifacts
   upload:
      name: Upload release-artifacts
-     runs-on: ubuntu-20.04
+     runs-on: ubuntu-24.04
      needs: generate
      permissions:
       actions: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   security-repo-scan:
     name: security-repo-scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       security-events: write
       actions: read
@@ -51,7 +51,7 @@ jobs:
         config:
           - image: krakend/krakend-ce
             dockerfile: Dockerfile
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -14,7 +14,7 @@ name: Upload cache to release page
 jobs:
   upload:
     name: Upload release-artifacts
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       packages: write


### PR DESCRIPTION
ubuntu 20.04 will be discontinued in a few weeks by github. upgrading to 24.04 (the latest LTS)
Also, always use the same version