### PR TITLE
Change docker image to point to the official one

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ See the [website](https://www.krakend.io) for more information.
 KrakenD is [packaged and distributed in several formats](https://www.krakend.io/download/). You don't need to clone this repo to use KrakenD unless you want to tweak and build the binary yourself.
 
 ## Run
-In its simplest form with Docker:
+In its simplest form with the [offical Docker image](https://hub.docker.com/_/krakend):
 
-    docker run -it -p "8080:8080" devopsfaith/krakend
+    docker run -it -p "8080:8080" krakend
 
 Now see [http://localhost:8080/__health](http://localhost:8080/__health). The gateway is listening. Now *CTRL-C* and replace  `/etc/krakend/krakend.json` with your [first configuration](https://designer.krakend.io).
 


### PR DESCRIPTION
Changed README to point to the right Docker image after the [announcement](https://www.krakend.io/blog/official-docker-image/)