### PR TITLE
update to cors 1.11.1 bug fix for allowed headers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/krakendio/krakend-cel/v2 v2.1.1
 	github.com/krakendio/krakend-circuitbreaker/v2 v2.0.1
 	github.com/krakendio/krakend-cobra/v2 v2.5.2
-	github.com/krakendio/krakend-cors/v2 v2.1.5-0.20250520064748-8ca7b5298c37
+	github.com/krakendio/krakend-cors/v2 v2.1.5
 	github.com/krakendio/krakend-flexibleconfig/v2 v2.2.2
 	github.com/krakendio/krakend-gelf/v2 v2.0.1
 	github.com/krakendio/krakend-gologging/v2 v2.0.3

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/krakendio/krakend-cel/v2 v2.1.1
 	github.com/krakendio/krakend-circuitbreaker/v2 v2.0.1
 	github.com/krakendio/krakend-cobra/v2 v2.5.2
-	github.com/krakendio/krakend-cors/v2 v2.1.4
+	github.com/krakendio/krakend-cors/v2 v2.1.5-0.20250520064748-8ca7b5298c37
 	github.com/krakendio/krakend-flexibleconfig/v2 v2.2.2
 	github.com/krakendio/krakend-gelf/v2 v2.0.1
 	github.com/krakendio/krakend-gologging/v2 v2.0.3
@@ -204,7 +204,7 @@ require (
 	github.com/prometheus/statsd_exporter v0.26.1 // indirect
 	github.com/rabbitmq/amqp091-go v1.9.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
-	github.com/rs/cors v1.11.0 // indirect
+	github.com/rs/cors v1.11.1 // indirect
 	github.com/rs/cors/wrapper/gin v0.0.0-20240830163046-1084d89a1692 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -490,8 +490,8 @@ github.com/krakendio/krakend-circuitbreaker/v2 v2.0.1 h1:rX5TAbdQa+mISIULDxYdviR
 github.com/krakendio/krakend-circuitbreaker/v2 v2.0.1/go.mod h1:PCbRQGfUOToK2Uw48gm9rZ8Mzb4qLGZnX4876Fu9CpQ=
 github.com/krakendio/krakend-cobra/v2 v2.5.2 h1:H0yDJChPVz0wRzokvNpCX6nDVGYSzCfP9cAN8wXMO7E=
 github.com/krakendio/krakend-cobra/v2 v2.5.2/go.mod h1:Zr5coJa58zeLwdZ6k3Os4ZPsJOtav/J86uO2Tg5YDTk=
-github.com/krakendio/krakend-cors/v2 v2.1.5-0.20250520064748-8ca7b5298c37 h1:UbHnu9OzY2MbQEfVlIT5rGCBjvmGfRacZedz/EV8Lyg=
-github.com/krakendio/krakend-cors/v2 v2.1.5-0.20250520064748-8ca7b5298c37/go.mod h1:F4JZLI2OByVlRjs0seEGdxcI/Fuu0fKO8SZHHynMGV0=
+github.com/krakendio/krakend-cors/v2 v2.1.5 h1:smExwifeRk5/de8TtIV7LJdoVdDrs2gL9oo/XZWnrgc=
+github.com/krakendio/krakend-cors/v2 v2.1.5/go.mod h1:F4JZLI2OByVlRjs0seEGdxcI/Fuu0fKO8SZHHynMGV0=
 github.com/krakendio/krakend-flexibleconfig/v2 v2.2.2 h1:B73KxlBbTY8pCaBQgxTvvI19IAOC2axfy43eCBZweXY=
 github.com/krakendio/krakend-flexibleconfig/v2 v2.2.2/go.mod h1:M+K56Y0j9US8SD6ThqoBMIclnAzzD1SiLdRRX6TM/Ns=
 github.com/krakendio/krakend-gelf/v2 v2.0.1 h1:OdcgKUOKvtLwFzoeCm5gAq0Vph6c7Kt6uL4OrxSw/P8=

--- a/go.sum
+++ b/go.sum
@@ -490,8 +490,8 @@ github.com/krakendio/krakend-circuitbreaker/v2 v2.0.1 h1:rX5TAbdQa+mISIULDxYdviR
 github.com/krakendio/krakend-circuitbreaker/v2 v2.0.1/go.mod h1:PCbRQGfUOToK2Uw48gm9rZ8Mzb4qLGZnX4876Fu9CpQ=
 github.com/krakendio/krakend-cobra/v2 v2.5.2 h1:H0yDJChPVz0wRzokvNpCX6nDVGYSzCfP9cAN8wXMO7E=
 github.com/krakendio/krakend-cobra/v2 v2.5.2/go.mod h1:Zr5coJa58zeLwdZ6k3Os4ZPsJOtav/J86uO2Tg5YDTk=
-github.com/krakendio/krakend-cors/v2 v2.1.4 h1:7KLxKFAzwWmHKgksx1R3sQdjmebbRlqevaHUbMS4kcs=
-github.com/krakendio/krakend-cors/v2 v2.1.4/go.mod h1:GnXFnGcUDr1cIKXcgIneh580VnmNmd1tjVLe5IGpQG4=
+github.com/krakendio/krakend-cors/v2 v2.1.5-0.20250520064748-8ca7b5298c37 h1:UbHnu9OzY2MbQEfVlIT5rGCBjvmGfRacZedz/EV8Lyg=
+github.com/krakendio/krakend-cors/v2 v2.1.5-0.20250520064748-8ca7b5298c37/go.mod h1:F4JZLI2OByVlRjs0seEGdxcI/Fuu0fKO8SZHHynMGV0=
 github.com/krakendio/krakend-flexibleconfig/v2 v2.2.2 h1:B73KxlBbTY8pCaBQgxTvvI19IAOC2axfy43eCBZweXY=
 github.com/krakendio/krakend-flexibleconfig/v2 v2.2.2/go.mod h1:M+K56Y0j9US8SD6ThqoBMIclnAzzD1SiLdRRX6TM/Ns=
 github.com/krakendio/krakend-gelf/v2 v2.0.1 h1:OdcgKUOKvtLwFzoeCm5gAq0Vph6c7Kt6uL4OrxSw/P8=
@@ -658,8 +658,8 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
-github.com/rs/cors v1.11.0 h1:0B9GE/r9Bc2UxRMMtymBkHTenPkHDv0CW4Y98GBY+po=
-github.com/rs/cors v1.11.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
+github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/cors/wrapper/gin v0.0.0-20240830163046-1084d89a1692 h1:lwzJgPw5Y6pvC8mwbedX9HfdywUKcpNdcviftZsb1uY=
 github.com/rs/cors/wrapper/gin v0.0.0-20240830163046-1084d89a1692/go.mod h1:742Ialb8SOs5yB2PqRDzFcyND3280PoaS5/wcKQUQKE=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
Use krakend-cors 2.1.5 , that uses `rs/cors` 1.11.1 