### PR TITLE
fix integration tests when no body and no schema is defined

### DIFF
--- a/tests/fixtures/specs/integration_no_body.json
+++ b/tests/fixtures/specs/integration_no_body.json
@@ -1,0 +1,21 @@
+{
+    "in": {
+        "method": "GET",
+        "url": "http://localhost:8080/static"
+    },
+    "out": {
+        "status_code": 200,
+        "@comment": "when no body and no schema are defined, body should not be checked",
+        "header": {
+            "content-type": [
+                "application/json; charset=utf-8"
+            ],
+            "Cache-Control": [
+                "public, max-age=3600"
+            ],
+            "X-Krakend-Completed": [
+                "true"
+            ]
+        }
+    }
+}

--- a/tests/integration.go
+++ b/tests/integration.go
@@ -450,7 +450,7 @@ func assertResponse(actual *http.Response, expected Output) error { // skipcq GO
 				errMessage: append(errMsgs, fmt.Sprintf("problem validating the body: %s", sanitizeValidationError(err))),
 			}
 		}
-	} else if expected.Body != "" {
+	} else if expected.Body != nil {
 		if !reflect.DeepEqual(body, expected.Body) {
 			errMsgs = append(errMsgs, fmt.Sprintf("unexpected body.\n\t\thave: %v\n\t\twant: %v", body, expected.Body))
 		}


### PR DESCRIPTION
Currently when not defining body nor schema, body is expected to be nil. With this change body won't be checked