### PR TITLE
CE patch release v2.13.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 BIN_NAME :=krakend
 OS := $(shell uname | tr '[:upper:]' '[:lower:]')
 MODULE := github.com/krakend/krakend-ce/v2
-VERSION := 2.13.6
+VERSION := 2.13.7
 SCHEMA_VERSION := $(shell echo "${VERSION}" | cut -d '.' -f 1,2)
 GIT_COMMIT := $(shell git rev-parse --short=7 HEAD)
 PKGNAME := krakend
@@ -21,7 +21,7 @@ DESC := High performance API gateway. Aggregate, filter, manipulate and add midd
 MAINTAINER := Daniel Ortiz <dortiz@krakend.io>
 DOCKER_WDIR := /tmp/fpm
 DOCKER_FPM := devopsfaith/fpm
-GOLANG_VERSION := 1.25.10
+GOLANG_VERSION := 1.25.11
 GLIBC_VERSION := $(shell sh find_glibc.sh)
 ALPINE_VERSION := 3.23
 OS_TAG :=

--- a/tests/fixtures/specs/backend_301.json
+++ b/tests/fixtures/specs/backend_301.json
@@ -5,7 +5,7 @@
 	},
 	"out": {
 		"status_code": 200,
-		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"Referer\":[\"http://127.0.0.1:8081/redirect/?status=301\"],\"User-Agent\":[\"KrakenD Version 2.13.6\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/\",\"query\":{\"status\":[\"301\"]}}",
+		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"Referer\":[\"http://127.0.0.1:8081/redirect/?status=301\"],\"User-Agent\":[\"KrakenD Version 2.13.7\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/\",\"query\":{\"status\":[\"301\"]}}",
 		"header": {
 			"content-type": ["application/json; charset=utf-8"],
 			"Cache-Control": ["public, max-age=3600"],

--- a/tests/fixtures/specs/backend_302.json
+++ b/tests/fixtures/specs/backend_302.json
@@ -5,7 +5,7 @@
 	},
 	"out": {
 		"status_code": 200,
-		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"Referer\":[\"http://127.0.0.1:8081/redirect/?status=302\"],\"User-Agent\":[\"KrakenD Version 2.13.6\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/\",\"query\":{\"status\":[\"302\"]}}",
+		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"Referer\":[\"http://127.0.0.1:8081/redirect/?status=302\"],\"User-Agent\":[\"KrakenD Version 2.13.7\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/\",\"query\":{\"status\":[\"302\"]}}",
 		"header": {
 			"content-type": ["application/json; charset=utf-8"],
 			"Cache-Control": ["public, max-age=3600"],

--- a/tests/fixtures/specs/backend_303.json
+++ b/tests/fixtures/specs/backend_303.json
@@ -5,7 +5,7 @@
 	},
 	"out": {
 		"status_code": 200,
-		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"Referer\":[\"http://127.0.0.1:8081/redirect/?status=303\"],\"User-Agent\":[\"KrakenD Version 2.13.6\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/\",\"query\":{\"status\":[\"303\"]}}",
+		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"Referer\":[\"http://127.0.0.1:8081/redirect/?status=303\"],\"User-Agent\":[\"KrakenD Version 2.13.7\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/\",\"query\":{\"status\":[\"303\"]}}",
 		"header": {
 			"content-type": ["application/json; charset=utf-8"],
 			"Cache-Control": ["public, max-age=3600"],

--- a/tests/fixtures/specs/backend_307.json
+++ b/tests/fixtures/specs/backend_307.json
@@ -5,7 +5,7 @@
 	},
 	"out": {
 		"status_code": 200,
-		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"Referer\":[\"http://127.0.0.1:8081/redirect/?status=307\"],\"User-Agent\":[\"KrakenD Version 2.13.6\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/\",\"query\":{\"status\":[\"307\"]}}",
+		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"Referer\":[\"http://127.0.0.1:8081/redirect/?status=307\"],\"User-Agent\":[\"KrakenD Version 2.13.7\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/\",\"query\":{\"status\":[\"307\"]}}",
 		"header": {
 			"content-type": ["application/json; charset=utf-8"],
 			"Cache-Control": ["public, max-age=3600"],

--- a/tests/fixtures/specs/cel-7.json
+++ b/tests/fixtures/specs/cel-7.json
@@ -12,7 +12,7 @@
 			"foo":42,
 			"headers":{
 				"Accept-Encoding":["gzip"],
-				"User-Agent":["KrakenD Version 2.13.6"],
+				"User-Agent":["KrakenD Version 2.13.7"],
 				"X-Forwarded-Host":["localhost:8080"]
 			},
 			"path":"/param_forwarding/ok/1234567890qwertyuio/foobar",

--- a/tests/fixtures/specs/cors_5.json
+++ b/tests/fixtures/specs/cors_5.json
@@ -9,12 +9,12 @@
 	},
 	"out": {
 		"status_code": 200,
-		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"User-Agent\":[\"KrakenD Version 2.13.6\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/bar\",\"query\":{\"foo\":[\"foo\"]}}",
+		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"User-Agent\":[\"KrakenD Version 2.13.7\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/bar\",\"query\":{\"foo\":[\"foo\"]}}",
 		"header": {
 			"content-type": ["application/json; charset=utf-8"],
 			"Cache-Control": ["public, max-age=3600"],
 			"X-Krakend-Completed": ["true"],
-			"X-Krakend": ["Version 2.13.6"],
+			"X-Krakend": ["Version 2.13.7"],
 			"Vary": ["Origin"],
 			"Access-Control-Allow-Origin": ["*"],
 			"Access-Control-Expose-Headers": ["Content-Length"]

--- a/tests/fixtures/specs/detail_error.json
+++ b/tests/fixtures/specs/detail_error.json
@@ -14,7 +14,7 @@
           "foo": 42,
           "headers": {
             "Accept-Encoding": ["gzip"],
-            "User-Agent": ["KrakenD Version 2.13.6"],
+            "User-Agent": ["KrakenD Version 2.13.7"],
             "X-Forwarded-Host": ["localhost:8080"]
           },
           "path": "/param_forwarding/",

--- a/tests/fixtures/specs/no-op_1.json
+++ b/tests/fixtures/specs/no-op_1.json
@@ -5,7 +5,7 @@
 	},
 	"out": {
 		"status_code": 200,
-		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"Content-Length\":[\"0\"],\"User-Agent\":[\"KrakenD Version 2.13.6\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/\",\"query\":{}}\n",
+		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"Content-Length\":[\"0\"],\"User-Agent\":[\"KrakenD Version 2.13.7\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/\",\"query\":{}}\n",
 		"header": {
 			"content-type": ["application/json"],
 			"Cache-Control": [""],

--- a/tests/fixtures/specs/param_forwarding_1.json
+++ b/tests/fixtures/specs/param_forwarding_1.json
@@ -10,7 +10,7 @@
 	},
 	"out": {
 		"status_code": 200,
-		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"Authorization\":[\"bearer 123456\"],\"User-Agent\":[\"KrakenD Version 2.13.6\"],\"X-Forwarded-Host\":[\"localhost:8080\"],\"X-Y-Z\":[\"true\"]},\"path\":\"/param_forwarding/bar\",\"query\":{\"foo\":[\"foo\"]}}",
+		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"Authorization\":[\"bearer 123456\"],\"User-Agent\":[\"KrakenD Version 2.13.7\"],\"X-Forwarded-Host\":[\"localhost:8080\"],\"X-Y-Z\":[\"true\"]},\"path\":\"/param_forwarding/bar\",\"query\":{\"foo\":[\"foo\"]}}",
 		"header": {
 			"content-type": ["application/json; charset=utf-8"],
 			"Cache-Control": ["public, max-age=3600"],

--- a/tests/fixtures/specs/param_forwarding_2.json
+++ b/tests/fixtures/specs/param_forwarding_2.json
@@ -10,7 +10,7 @@
 	},
 	"out": {
 		"status_code": 200,
-		"body": "{\"foo\":42,\"headers\":{\"A-B-C\":[\"ignore\"],\"Accept-Encoding\":[\"gzip\"],\"Authorization\":[\"bearer 123456\"],\"User-Agent\":[\"Go-http-client/1.1\"],\"X-Forwarded-Host\":[\"localhost:8080\"],\"X-Forwarded-Via\":[\"KrakenD Version 2.13.6\"],\"X-Y-Z\":[\"true\"]},\"path\":\"/param_forwarding/bar\",\"query\":{\"foo\":[\"foo\"]}}",
+		"body": "{\"foo\":42,\"headers\":{\"A-B-C\":[\"ignore\"],\"Accept-Encoding\":[\"gzip\"],\"Authorization\":[\"bearer 123456\"],\"User-Agent\":[\"Go-http-client/1.1\"],\"X-Forwarded-Host\":[\"localhost:8080\"],\"X-Forwarded-Via\":[\"KrakenD Version 2.13.7\"],\"X-Y-Z\":[\"true\"]},\"path\":\"/param_forwarding/bar\",\"query\":{\"foo\":[\"foo\"]}}",
 		"header": {
 			"content-type": ["application/json; charset=utf-8"],
 			"Cache-Control": ["public, max-age=3600"],

--- a/tests/fixtures/specs/param_forwarding_3.json
+++ b/tests/fixtures/specs/param_forwarding_3.json
@@ -10,7 +10,7 @@
 	},
 	"out": {
 		"status_code": 200,
-		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"Authorization\":[\"bearer 123456\"],\"User-Agent\":[\"KrakenD Version 2.13.6\"],\"X-Forwarded-Host\":[\"localhost:8080\"],\"X-Y-Z\":[\"true\"]},\"path\":\"/param_forwarding/bar\",\"query\":{\"foo\":[\"foo\"]}}",
+		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"Authorization\":[\"bearer 123456\"],\"User-Agent\":[\"KrakenD Version 2.13.7\"],\"X-Forwarded-Host\":[\"localhost:8080\"],\"X-Y-Z\":[\"true\"]},\"path\":\"/param_forwarding/bar\",\"query\":{\"foo\":[\"foo\"]}}",
 		"header": {
 			"content-type": ["application/json; charset=utf-8"],
 			"Cache-Control": ["public, max-age=3600"],

--- a/tests/fixtures/specs/param_forwarding_4.json
+++ b/tests/fixtures/specs/param_forwarding_4.json
@@ -17,7 +17,7 @@
 			"headers":{
 				"Accept-Encoding":["gzip"],
 				"Authorization":["bearer 123456"],
-				"User-Agent":["KrakenD Version 2.13.6"],
+				"User-Agent":["KrakenD Version 2.13.7"],
 				"X-Forwarded-Host":["localhost:8080"],
 				"X-Y-Z":["true"]
 			},

--- a/tests/fixtures/specs/query_forwarding_1.json
+++ b/tests/fixtures/specs/query_forwarding_1.json
@@ -8,7 +8,7 @@
 	},
 	"out": {
 		"status_code": 200,
-		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"User-Agent\":[\"KrakenD Version 2.13.6\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/foo\",\"query\":{\"a\":[\"1\"],\"b\":[\"2\"]}}",
+		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"User-Agent\":[\"KrakenD Version 2.13.7\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/foo\",\"query\":{\"a\":[\"1\"],\"b\":[\"2\"]}}",
 		"header": {
 			"content-type": ["application/json; charset=utf-8"],
 			"Cache-Control": ["public, max-age=3600"],

--- a/tests/fixtures/specs/query_forwarding_2.json
+++ b/tests/fixtures/specs/query_forwarding_2.json
@@ -5,7 +5,7 @@
 	},
 	"out": {
 		"status_code": 200,
-		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"User-Agent\":[\"KrakenD Version 2.13.6\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/foo\",\"query\":{\"a\":[\"1\"],\"b\":[\"2\",\"3\"]}}",
+		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"User-Agent\":[\"KrakenD Version 2.13.7\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/foo\",\"query\":{\"a\":[\"1\"],\"b\":[\"2\",\"3\"]}}",
 		"header": {
 			"content-type": ["application/json; charset=utf-8"],
 			"Cache-Control": ["public, max-age=3600"],

--- a/tests/fixtures/specs/query_forwarding_3.json
+++ b/tests/fixtures/specs/query_forwarding_3.json
@@ -5,7 +5,7 @@
 	},
 	"out": {
 		"status_code": 200,
-		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"User-Agent\":[\"KrakenD Version 2.13.6\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/foo\",\"query\":{\"a\":[\"1\"]}}",
+		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"User-Agent\":[\"KrakenD Version 2.13.7\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/foo\",\"query\":{\"a\":[\"1\"]}}",
 		"header": {
 			"content-type": ["application/json; charset=utf-8"],
 			"Cache-Control": ["public, max-age=3600"],

--- a/tests/fixtures/specs/sequential_1.json
+++ b/tests/fixtures/specs/sequential_1.json
@@ -5,7 +5,7 @@
 	},
 	"out": {
 		"status_code": 200,
-		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"User-Agent\":[\"KrakenD Version 2.13.6\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/42\",\"query\":{}}",
+		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"User-Agent\":[\"KrakenD Version 2.13.7\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/42\",\"query\":{}}",
 		"header": {
 			"content-type": ["application/json; charset=utf-8"],
 			"Cache-Control": ["public, max-age=3600"],

--- a/tests/fixtures/specs/sequential_4.json
+++ b/tests/fixtures/specs/sequential_4.json
@@ -5,7 +5,7 @@
 	},
 	"out": {
 		"status_code": 200,
-		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"User-Agent\":[\"KrakenD Version 2.13.6\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/eyJtZXNzYWdlIjoicG9uZyJ9\",\"query\":{}}",
+		"body": "{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"User-Agent\":[\"KrakenD Version 2.13.7\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/eyJtZXNzYWdlIjoicG9uZyJ9\",\"query\":{}}",
 		"header": {
 			"content-type": ["application/json; charset=utf-8"],
 			"Cache-Control": ["public, max-age=3600"],

--- a/tests/fixtures/specs/timeout.json
+++ b/tests/fixtures/specs/timeout.json
@@ -5,7 +5,7 @@
 	},
 	"out": {
 		"status_code": 200,
-		"body": "{\"first\":{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"User-Agent\":[\"KrakenD Version 2.13.6\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/123\",\"query\":{}}}",
+		"body": "{\"first\":{\"foo\":42,\"headers\":{\"Accept-Encoding\":[\"gzip\"],\"User-Agent\":[\"KrakenD Version 2.13.7\"],\"X-Forwarded-Host\":[\"localhost:8080\"]},\"path\":\"/param_forwarding/123\",\"query\":{}}}",
 		"header": {
 			"content-type": ["application/json; charset=utf-8"],
 			"Cache-Control": [""],

--- a/tests/fixtures/specs/xml_2.json
+++ b/tests/fixtures/specs/xml_2.json
@@ -5,7 +5,7 @@
 	},
 	"out": {
 		"status_code": 200,
-		"body": "<doc><foo>42</foo><headers><Accept-Encoding>gzip</Accept-Encoding><Referer>http://127.0.0.1:8081/param_forwarding</Referer><User-Agent>KrakenD Version 2.13.6</User-Agent><X-Forwarded-Host>localhost:8080</X-Forwarded-Host></headers><path>/param_forwarding/</path><query/></doc>",
+		"body": "<doc><foo>42</foo><headers><Accept-Encoding>gzip</Accept-Encoding><Referer>http://127.0.0.1:8081/param_forwarding</Referer><User-Agent>KrakenD Version 2.13.7</User-Agent><X-Forwarded-Host>localhost:8080</X-Forwarded-Host></headers><path>/param_forwarding/</path><query/></doc>",
 		"header": {
 			"content-type": ["application/xml"],
 			"Cache-Control": ["public, max-age=3600"],


### PR DESCRIPTION
## Changes

Upgraded Go to 1.25.11, addressing several CVEs with disclosed descriptions:

* [CVE-2026-42504](https://go.dev/issue/79217) `mime`: quadratic complexity in WordDecoder.DecodeHeader
* [CVE-2026-42507](https://go.dev/issue/79346) `net/textproto`: arbitrary input are included in errors without any escaping
* [CVE-2026-27145](https://go.dev/issue/79694) `crypto/x509`: split candidate hostname only once