### PR TITLE
Point the README link to the open-source page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 KrakenD is an extensible, ultra-high performance API Gateway that helps you effortlessly adopt microservices and secure communications. KrakenD is easy to operate and run and scales out without a single point of failure.
 
-**KrakenD Community Edition** (or *KrakenD-CE*) is the open-source distribution of [KrakenD](https://www.krakend.io).
+**KrakenD Community Edition** (or *KrakenD-CE*) is the open-source distribution of the [KrakenD API Gateway](https://www.krakend.io/open-source/).
 
 [KrakenD Site](https://www.krakend.io/) | [Documentation](https://www.krakend.io/docs/overview/) | [Blog](https://www.krakend.io/blog/) | [Twitter](https://twitter.com/krakend_io) | [Downloads](https://www.krakend.io/download/)
 


### PR DESCRIPTION
Small tidy — the intro links KrakenD to the homepage, but there's a dedicated open-source page now, so pointing it there.